### PR TITLE
[BUGFIX] Return ssh port parameter

### DIFF
--- a/JoRo/Typo3ReverseDeployment.php
+++ b/JoRo/Typo3ReverseDeployment.php
@@ -166,11 +166,11 @@ Class Typo3ReverseDeployment
     }
 
     /**
-     * Build ssh port parameter
+     * Build and return ssh port parameter
      */
     public function getSshPortParam()
     {
-        $this->sshPortParam = '-e "ssh -p ' . $this->sshPort . '"';
+        return '-e "ssh -p ' . $this->sshPort . '"';
     }
 
     /**

--- a/JoRo/Typo3ReverseDeployment.php
+++ b/JoRo/Typo3ReverseDeployment.php
@@ -170,7 +170,7 @@ Class Typo3ReverseDeployment
      */
     public function getSshPortParam()
     {
-        return '-e "ssh -p ' . $this->sshPort . '"';
+        return '-e "ssh -p ' . $this->getSshPort() . '"';
     }
 
     /**


### PR DESCRIPTION
The ssh port parameter was written to `$this->sshPortParam` but never used. The getter did not return anything, so it was not possible to use rsync with servers that use another SSH port than default 22.

With this change, the ssh port parameter is returned by getter and rsync works with non-default ssh ports.