### PR TITLE
[FEATURE] Add example to configure alternative SSH port

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ $reverseDeploy->setTypo3RootPath('/var/www/html/');
  */
 $reverseDeploy->setPrivateKey(getenv("HOME") . '/.ssh/id_rsa');
 $reverseDeploy->setUser('USERNAME');
+// optional: $reverseDeploy->setSshPort(222);
 $ssh = $reverseDeploy->ssh('example.org');
 
 /**

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ $reverseDeploy->setTypo3RootPath('/var/www/html/');
 /**
  * Connect to Server
  */
-// optional: $reverseDeploy->setPrivateKey(getenv("HOME") . '/.ssh/id_rsa');
 $reverseDeploy->setUser('USERNAME');
+// optional: $reverseDeploy->setPrivateKey(getenv('HOME') . '/.ssh/id_rsa');
 // optional: $reverseDeploy->setSshPort(222);
 $ssh = $reverseDeploy->ssh('example.org');
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ $reverseDeploy->setTypo3RootPath('/var/www/html/');
 /**
  * Connect to Server
  */
-$reverseDeploy->setPrivateKey(getenv("HOME") . '/.ssh/id_rsa');
+// optional: $reverseDeploy->setPrivateKey(getenv("HOME") . '/.ssh/id_rsa');
 $reverseDeploy->setUser('USERNAME');
 // optional: $reverseDeploy->setSshPort(222);
 $ssh = $reverseDeploy->ssh('example.org');


### PR DESCRIPTION
The additional (disabled) line in global README could help new users to find the configuration option

```php
// optional: $reverseDeploy->setSshPort(222);
```