### PR TITLE
[CLEANUP] Avoid PHP notice when running the tool without parameters

### DIFF
--- a/typo3reverse
+++ b/typo3reverse
@@ -14,7 +14,7 @@ use TYPO3\Flow\Utility\Files;
 
 $factory = new \JoRo\ReversePath();
 
-if(in_array($argv[1],$factory->getDeploymentNames())) {
+if(isset($argv[1]) && in_array($argv[1],$factory->getDeploymentNames())) {
     $deploymentName = $argv[1];
 } else {
     $deploymentName = $factory->getDeploymentNames()[0];


### PR DESCRIPTION
Running `typo3reverse` without a deployment name as parameter causes a PHP notice

```
PHP Notice:  Undefined offset: 1 in ~/.composer/vendor/joro/typo3reversedeployment/typo3reverse on line 18

Notice: Undefined offset: 1 in ~/.composer/vendor/joro/typo3reversedeployment/typo3reverse on line 18
```

This bugfix checks, if an argument ist given, before trying to use it.