### PR TITLE
[BUGFIX] Use full datetime in MySQL dump

### DIFF
--- a/JoRo/Typo3ReverseDeployment.php
+++ b/JoRo/Typo3ReverseDeployment.php
@@ -429,7 +429,7 @@ Class Typo3ReverseDeployment
         /**
          * Export and download database
          */
-        $sqlRemoteTarget = $this->getTypo3RootPath() . 'typo3temp/joro_typo3reversedeployment/' . date("Ymds") . "-" . $conf['dbname'] . ".sql";
+        $sqlRemoteTarget = $this->getTypo3RootPath() . 'typo3temp/joro_typo3reversedeployment/' . date("YmdHis") . "-" . $conf['dbname'] . ".sql";
         $sqlExport = "cd " . $this->getTypo3RootPath() . " && " . $this->getPhpPathAndBinary() . " ../vendor/bin/typo3cms database:export";
 
         echo "\033[32mExport DB: $sqlExport\033[0m" . PHP_EOL;


### PR DESCRIPTION
It would be great to have a full date time in MySQL dump file name. So it can be sorted correctly, when creating multiple dumps during the same day.