### PR TITLE
[FEATURE] Read database configuration from TYPO3 7

### DIFF
--- a/JoRo/Typo3ReverseDeployment.php
+++ b/JoRo/Typo3ReverseDeployment.php
@@ -403,7 +403,17 @@ Class Typo3ReverseDeployment
         $phpConfig = str_replace('<?php', '', $remoteConf);
         $conf = eval($phpConfig);
 
-        return $conf['DB']['Connections'][$this->getConnectionPool()];
+        if(isset($conf['DB']['Connections'])) { // current TYPO3 versions
+            return $conf['DB']['Connections'][$this->getConnectionPool()];
+        } else { // simple fallback for TYPO3 7
+            return [
+                'driver' => 'mysqli',
+                'host' => $conf['DB']['host'],
+                'user' => $conf['DB']['username'],
+                'password' => $conf['DB']['password'],
+                'dbname' => $conf['DB']['database']
+            ];
+        }
     }
 
     /**


### PR DESCRIPTION
Format of DB configuration in `LocalConfiguration.php` differs from TYPO3 7 to TYPO3 8. To support reverse deployment with TYPO3 7 projects, the older format must be converted.