### PR TITLE
[TASK] Get database connection with typo3-console

### DIFF
--- a/JoRo/Typo3ReverseDeployment.php
+++ b/JoRo/Typo3ReverseDeployment.php
@@ -466,21 +466,20 @@ Class Typo3ReverseDeployment
      */
     public function getLocalConfiguration($ssh)
     {
-        $path = $this->getTypo3RootPath();
-        $remoteConf = $ssh->exec($this->getPhpPathAndBinary() . " -r 'echo file_get_contents(\"$path/typo3conf/LocalConfiguration.php\");'");
+        $remoteCommand = "cd " . $this->getTypo3RootPath() . " && " . $this->getPhpPathAndBinary()
+            . " " . $this->getPathToConsoleExecutable() . " configuration:showactive DB --json";
+        $remoteCommandResult = $ssh->exec($remoteCommand);
+        $conf = json_decode($remoteCommandResult, true);
 
-        $phpConfig = str_replace('<?php', '', $remoteConf);
-        $conf = eval($phpConfig);
-
-        if(isset($conf['DB']['Connections'])) { // current TYPO3 versions
-            return $conf['DB']['Connections'][$this->getConnectionPool()];
+        if(isset($conf['Connections'])) { // current TYPO3 versions
+            return $conf['Connections'][$this->getConnectionPool()];
         } else { // simple fallback for TYPO3 7
             return [
                 'driver' => 'mysqli',
-                'host' => $conf['DB']['host'],
-                'user' => $conf['DB']['username'],
-                'password' => $conf['DB']['password'],
-                'dbname' => $conf['DB']['database']
+                'host' => $conf['host'],
+                'user' => $conf['username'],
+                'password' => $conf['password'],
+                'dbname' => $conf['database']
             ];
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "Export DB and files to your TYPO3 dev installation",
     "license": "GPL-3.0-or-later",
     "require": {
+        "helhum/typo3-console": "^4.6.0 || ^5.2",
         "phpseclib/phpseclib": "^2.0",
         "neos/utility-files": "^3.0"
     },


### PR DESCRIPTION
Use typo3-console to get the database connection. This feature works with typo3-console 4.6.0 or higher.