### PR TITLE
Catch undefined method calls and show hint to update to latest version

### DIFF
--- a/JoRo/Typo3ReverseDeployment.php
+++ b/JoRo/Typo3ReverseDeployment.php
@@ -634,6 +634,6 @@ Class Typo3ReverseDeployment
      */
     public function __call($name, $args)
     {
-        exit("\033[31mThe method '$name' which is used in your reverse deployment configuration cannot be found in the installed version of joro/reversedeployment. Please install the latest version of joro/reversedeployment.\033[0m" . PHP_EOL);
+        exit("\033[31mThe method '$name', which is used in your reverse deployment configuration, cannot be found in the installed version of joro/reversedeployment. Please install the latest version of joro/reversedeployment.\033[0m" . PHP_EOL);
     }
 }

--- a/JoRo/Typo3ReverseDeployment.php
+++ b/JoRo/Typo3ReverseDeployment.php
@@ -625,4 +625,15 @@ Class Typo3ReverseDeployment
         $ssh->exec($this->getPhpPathAndBinary() . " -r 'mkdir(\"$tempFolder\", 0777, true);'");
         $ssh->exec($this->getPhpPathAndBinary() . " -r 'file_put_contents(\"$htaccess\",\"deny from all\");'");
     }
+
+    /**
+     * Catch undefined method calls and show hint to update to latest version.
+     *
+     * @param $name
+     * @param $args
+     */
+    public function __call($name, $args)
+    {
+        exit("\033[31mThe method '$name' which is used in your reverse deployment configuration cannot be found in the installed version of joro/reversedeployment. Please install the latest version of joro/reversedeployment.\033[0m" . PHP_EOL);
+    }
 }


### PR DESCRIPTION
In big teams, it could be possible, that different co-workers have different version of "joro/typo3reversedeployment" installed. So it could happen, someone adds a method to the configuration, wich does not exist in another's installed version.

This merge request shows a nicer and better readable error message for this cases.