### PR TITLE
TYPO3 11 Compatibility

### DIFF
--- a/JoRo/Typo3ReverseDeployment.php
+++ b/JoRo/Typo3ReverseDeployment.php
@@ -608,7 +608,7 @@ class Typo3ReverseDeployment
         $this->ensureRemoteDirectoryExists();
         $conf = $this->getLocalConfiguration();
 
-        $ignoredTables = count($this->sqlExcludeTable) > 0 ? '--exclude-tables ' : '';
+        $ignoredTables = count($this->sqlExcludeTable) > 0 ? '-e ' : '';
         foreach ($this->sqlExcludeTable as $exclude) {
             $ignoredTables .= end($this->sqlExcludeTable) === $exclude ? $exclude . '' : $exclude . ',';
         }


### PR DESCRIPTION
Test case : 

TYPO3:  11.5.3
TYPO3 console : 7.0.4 

Execute command  **~/joro-typo3reversedeployment/typo3reverse**

Error msg: 

  [ Symfony\Component\Console\Exception\RuntimeException ]  
  The "--exclude-tables" option does not exist.         



